### PR TITLE
Clear UART TC flag on stream startup.

### DIFF
--- a/src/platform/stm32/stm32_uart_stream.c
+++ b/src/platform/stm32/stm32_uart_stream.c
@@ -238,6 +238,11 @@ stm32_uart_stream_init(stm32_uart_stream_t *u, int reg_base, int baudrate,
   u->tx_dma = STM32_DMA_INSTANCE_NONE;
   u->stream.write = stm32_uart_write;
 
+  /* Clear TC (transmission complete) flag which is set in SR by default.
+   * Although the docs state that clearing should be a SR read followed by a DR
+   * write, that sequence doesn't seem to work but a simple read does. */
+  reg_rd(u->reg_base + USART_SR);
+
   irq_enable(irq, IRQ_LEVEL_CONSOLE);
 
   u->stream.read = stm32_uart_read;


### PR DESCRIPTION
I/O was blocked until the UART SR register was read (clearing the TC flag) which happens on RX-IRQ.

Clearing TC should be done by reading SR and then writing DR but that seems to keep I/O blocked, while just reading SR unblocks it. It's unclear why.