### PR TITLE
stm32 : move tx_enable pin cfg for uart_stream to own function

### DIFF
--- a/src/platform/stm32/stm32_uart_stream.h
+++ b/src/platform/stm32/stm32_uart_stream.h
@@ -24,7 +24,11 @@ typedef struct stm32_uart_stream {
   uint8_t flags;
 
   gpio_t tx_enable;
+  uint8_t tx_pol_invert;
   uint8_t tx_enabled;
+
+  gpio_t rx_enable;
+  uint8_t rx_pol_invert;
 
   uint8_t rx_fifo_rdptr;
   uint8_t rx_fifo_wrptr;

--- a/src/platform/stm32f4/stm32f4_uart.h
+++ b/src/platform/stm32f4/stm32f4_uart.h
@@ -27,13 +27,16 @@ typedef struct {
   uint32_t rxdma;
 } stm32f4_uart_config_t;
 
-stream_t *stm32f4_uart_stream_init(struct stm32_uart_stream *uart,
-                                   int instance, int baudrate,
-                                   gpio_t tx, gpio_t rx, gpio_t tx_enable,
+stream_t *stm32f4_uart_stream_init(struct stm32_uart_stream *uart, int instance,
+                                   int baudrate, gpio_t tx, gpio_t rx,
                                    uint8_t flags, const char *name);
 
 void stm32f4_uart_mbus_multidrop_create(unsigned int instance,
                                         gpio_t tx, gpio_t rx, gpio_t txe,
                                         const char *name);
+
+void stm32f4_uart_set_io_ctrl(stream_t *uart, gpio_t tx_enable,
+                              int tx_pol_invert, gpio_t rx_enable,
+                              int rx_pol_invert);
 
 const stm32f4_uart_config_t *stm32f4_uart_get_config(int index);

--- a/src/platform/stm32f4/stm32f4_uart_stream.c
+++ b/src/platform/stm32f4/stm32f4_uart_stream.c
@@ -24,10 +24,16 @@ stm32f4_uart_get_config(int index)
 
 static stm32_uart_stream_t *uarts[6];
 
+void
+stm32f4_uart_set_io_ctrl(stream_t *s, gpio_t tx_enable, int tx_pol_invert,
+                         gpio_t rx_enable, int rx_pol_invert)
+{
+  stm32_uart_set_io_ctrl(s, tx_enable, tx_pol_invert, rx_enable, rx_pol_invert);
+}
+
 stream_t *
 stm32f4_uart_stream_init(stm32_uart_stream_t *u, int instance, int baudrate,
-                         gpio_t tx, gpio_t rx, gpio_t tx_enable, uint8_t flags,
-                         const char *name)
+                         gpio_t tx, gpio_t rx, uint8_t flags, const char *name)
 {
   const int index = instance - 1;
   const stm32f4_uart_config_t *cfg = stm32f4_uart_get_config(index);
@@ -46,7 +52,6 @@ stm32f4_uart_stream_init(stm32_uart_stream_t *u, int instance, int baudrate,
                              cfg->clkid,
                              cfg->irq,
                              flags,
-                             tx_enable,
                              name);
 
   uarts[index] = u;

--- a/src/platform/stm32f405-feather/stm32f405-feather.c
+++ b/src/platform/stm32f405-feather/stm32f405-feather.c
@@ -21,7 +21,7 @@ board_init_console(void)
 {
   static stm32_uart_stream_t console;
   stdio = stm32f4_uart_stream_init(&console, 6, 115200, GPIO_PC(6), GPIO_PC(7),
-                                   GPIO_UNUSED, UART_CTRLD_IS_PANIC, "console");
+                                   UART_CTRLD_IS_PANIC, "console");
 }
 
 

--- a/src/platform/stm32f407g-disc1/stm32f407g-disc1.c
+++ b/src/platform/stm32f407g-disc1/stm32f407g-disc1.c
@@ -18,7 +18,7 @@ board_init_console(void)
 {
   static stm32_uart_stream_t console;
   stdio = stm32f4_uart_stream_init(&console, 2, 115200, GPIO_PA(2), GPIO_PA(3),
-                                   GPIO_UNUSED, UART_CTRLD_IS_PANIC, "console");
+                                   UART_CTRLD_IS_PANIC, "console");
 }
 
 

--- a/src/platform/stm32f439-nucleo144/stm32f439-nucleo144.c
+++ b/src/platform/stm32f439-nucleo144/stm32f439-nucleo144.c
@@ -23,7 +23,7 @@ board_init_console(void)
 {
   static stm32_uart_stream_t console;
   stdio = stm32f4_uart_stream_init(&console, 3, 115200, GPIO_PD(8), GPIO_PD(9),
-                                   GPIO_UNUSED, UART_CTRLD_IS_PANIC, "console");
+                                   UART_CTRLD_IS_PANIC, "console");
 }
 
 static const uint8_t stm32f439_nucleo144_ethernet_gpios[] =

--- a/src/platform/stm32g0/stm32g0_uart_stream.c
+++ b/src/platform/stm32g0/stm32g0_uart_stream.c
@@ -79,7 +79,6 @@ stm32g0_uart_stream_init(stm32_uart_stream_t *u, unsigned int instance,
                              cfg->clkid,
                              cfg->irq,
                              flags,
-                             GPIO_UNUSED,
                              name);
 
   uarts[instance - 1] = u;


### PR DESCRIPTION
Also add rx_enable and pin polarity options.
This is needed for RS485 where the receive enable
pin must be disabled while transmitting (in half-duplex mode) and also has inverted polarity.