### PR TITLE
added bt81x_touch_xy() for synchronous touch reads

### DIFF
--- a/src/drivers/gpu/bt81x/bt81x.c
+++ b/src/drivers/gpu/bt81x/bt81x.c
@@ -106,7 +106,6 @@ bt81x_rd32(bt81x_t *b, uint32_t addr)
 }
 
 
-
 static void
 bt81x_cmd(bt81x_t *b, uint8_t command, uint8_t param)
 {
@@ -788,6 +787,14 @@ bt81x_backlight(gfx_display_t *gd, uint8_t backlight)
 }
 
 
+uint32_t
+bt81x_touch_xy(gfx_display_t *gd)
+{
+  bt81x_t *b = (bt81x_t *)gd;
+  return bt81x_rd32(b, EVE_REG_CTOUCH_TOUCH0_XY);
+}
+
+
 /************************************************************************
  *
  * GUI draw primitives
@@ -1285,3 +1292,4 @@ cmd_gpu_info(cli_t *cli, int argc, char **argv)
 
 CLI_CMD_DEF("gpu_info", cmd_gpu_info);
 #endif
+

--- a/src/drivers/gpu/bt81x/bt81x.h
+++ b/src/drivers/gpu/bt81x/bt81x.h
@@ -52,3 +52,6 @@ struct gfx_display *bt81x_create(spi_t *spi, gpio_t ncs, gpio_t pd, gpio_t irq,
 void bt81x_enable(struct gfx_display *, int enabled);
 
 void bt81x_backlight(struct gfx_display *, uint8_t backlight);
+
+uint32_t bt81x_touch_xy(struct gfx_display *gd);
+


### PR DESCRIPTION
added a touch screen support function

uses EVE_REG_CTOUCH_TOUCH0_XY rather than EVE_REG_TOUCH_RAW_XY - valid for both the BT815/816 (resistive) and BT817/818 (capacitive) controllers when configured in compatibility mode, which is already set up in bt81x_initialize.